### PR TITLE
Add token cancellation to invoke api functions

### DIFF
--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/IMobileServiceClient.cs
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/IMobileServiceClient.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.WindowsAzure.MobileServices.Sync;
 using Newtonsoft.Json.Linq;
+using System.Threading;
 
 namespace Microsoft.WindowsAzure.MobileServices
 {
@@ -160,6 +161,15 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// <returns>The response content from the custom api invocation.</returns>
         Task<T> InvokeApiAsync<T>(string apiName);
 
+		/// <summary>
+		/// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using an HTTP POST.
+		/// </summary>
+		/// <typeparam name="T">The type of instance returned from the Microsoft Azure Mobile Service.</typeparam>    
+		/// <param name="apiName">The name of the custom API.</param>
+		/// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> token to observe</param>
+		/// <returns>The response content from the custom api invocation.</returns>
+		Task<T> InvokeApiAsync<T>(string apiName, CancellationToken cancellationToken);
+
         /// <summary>
         /// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using an HTTP POST with
         /// support for sending HTTP content.
@@ -170,6 +180,18 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// <param name="body">The value to be sent as the HTTP body.</param>
         /// <returns>The response content from the custom api invocation.</returns>
         Task<U> InvokeApiAsync<T, U>(string apiName, T body);
+
+		/// <summary>
+		/// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using an HTTP POST with
+		/// support for sending HTTP content.
+		/// </summary>
+		/// <typeparam name="T">The type of instance sent to the Microsoft Azure Mobile Service.</typeparam>
+		/// <typeparam name="U">The type of instance returned from the Microsoft Azure Mobile Service.</typeparam>    
+		/// <param name="apiName">The name of the custom API.</param>
+		/// <param name="body">The value to be sent as the HTTP body.</param>
+		/// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> token to observe</param>
+		/// <returns>The response content from the custom api invocation.</returns>
+		Task<U> InvokeApiAsync<T, U>(string apiName, T body, CancellationToken cancellationToken);
 
         /// <summary>
         /// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using the specified HTTP Method.
@@ -183,6 +205,20 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// </param>
         /// <returns>The response content from the custom api invocation.</returns>
         Task<T> InvokeApiAsync<T>(string apiName, HttpMethod method, IDictionary<string, string> parameters);
+
+		/// <summary>
+		/// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using the specified HTTP Method.
+		/// Additional data can be passed using the query string.
+		/// </summary>
+		/// <typeparam name="T">The type of instance sent to the Microsoft Azure Mobile Service.</typeparam>
+		/// <param name="apiName">The name of the custom API.</param>
+		/// <param name="method">The HTTP method.</param>
+		/// <param name="parameters">
+		/// A dictionary of user-defined parameters and values to include in the request URI query string.
+		/// </param>
+		/// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> token to observe</param>
+		/// <returns>The response content from the custom api invocation.</returns>
+		Task<T> InvokeApiAsync<T>(string apiName, HttpMethod method, IDictionary<string, string> parameters, CancellationToken cancellationToken);
 
         /// <summary>
         /// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using the specified HTTP Method.
@@ -199,12 +235,36 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// <returns>The response content from the custom api invocation.</returns>
         Task<U> InvokeApiAsync<T, U>(string apiName, T body, HttpMethod method, IDictionary<string, string> parameters);
 
+		/// <summary>
+		/// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using the specified HTTP Method.
+		/// Additional data can be sent though the HTTP content or the query string.
+		/// </summary>
+		/// <typeparam name="T">The type of instance sent to the Microsoft Azure Mobile Service.</typeparam>
+		/// <typeparam name="U">The type of instance returned from the Microsoft Azure Mobile Service.</typeparam>    
+		/// <param name="apiName">The name of the custom API.</param>
+		/// <param name="body">The value to be sent as the HTTP body.</param>
+		/// <param name="method">The HTTP method.</param>
+		/// <param name="parameters">
+		/// A dictionary of user-defined parameters and values to include in the request URI query string.
+		/// </param>
+		/// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> token to observe</param>
+		/// <returns>The response content from the custom api invocation.</returns>
+		Task<U> InvokeApiAsync<T, U>(string apiName, T body, HttpMethod method, IDictionary<string, string> parameters, CancellationToken cancellationToken);
+
         /// <summary>
         /// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using an HTTP POST.
         /// </summary>
         /// <param name="apiName">The name of the custom API.</param>
         /// <returns></returns>
         Task<JToken> InvokeApiAsync(string apiName);
+
+		/// <summary>
+		/// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using an HTTP POST.
+		/// </summary>
+		/// <param name="apiName">The name of the custom API.</param>
+		/// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> token to observe</param>
+		/// <returns></returns>
+		Task<JToken> InvokeApiAsync(string apiName, CancellationToken cancellationToken);
 
         /// <summary>
         /// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using an HTTP POST, with
@@ -214,6 +274,16 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// <param name="body">The value to be sent as the HTTP body.</param>
         /// <returns></returns>
         Task<JToken> InvokeApiAsync(string apiName, JToken body);
+
+		/// <summary>
+		/// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using an HTTP POST, with
+		/// support for sending HTTP content.
+		/// </summary>
+		/// <param name="apiName">The name of the custom API.</param>
+		/// <param name="body">The value to be sent as the HTTP body.</param>
+		/// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> token to observe</param>
+		/// <returns></returns>
+		Task<JToken> InvokeApiAsync(string apiName, JToken body, CancellationToken cancellationToken);
 
         /// <summary>
         /// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using the specified HTTP Method.
@@ -226,6 +296,19 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// </param>
         /// <returns>The response content from the custom api invocation.</returns>
         Task<JToken> InvokeApiAsync(string apiName, HttpMethod method, IDictionary<string, string> parameters);
+
+		/// <summary>
+		/// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using the specified HTTP Method.
+		/// Additional data will sent to through the query string.
+		/// </summary>
+		/// <param name="apiName">The name of the custom API.</param>
+		/// <param name="method">The HTTP method.</param>
+		/// <param name="parameters">
+		/// A dictionary of user-defined parameters and values to include in the request URI query string.
+		/// </param>
+		/// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> token to observe</param>
+		/// <returns>The response content from the custom api invocation.</returns>
+		Task<JToken> InvokeApiAsync(string apiName, HttpMethod method, IDictionary<string, string> parameters, CancellationToken cancellationToken);
 
         /// <summary>
         /// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using the specified HTTP method.
@@ -240,6 +323,20 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// <returns>The response content from the custom api invocation.</returns>
         Task<JToken> InvokeApiAsync(string apiName, JToken body, HttpMethod method, IDictionary<string, string> parameters);
         
+		/// <summary>
+		/// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using the specified HTTP method.
+		/// Additional data can be sent though the HTTP content or the query string.
+		/// </summary>
+		/// <param name="apiName">The name of the custom API.</param>
+		/// <param name="body">The value to be sent as the HTTP body.</param>
+		/// <param name="method">The HTTP method.</param>
+		/// <param name="parameters">
+		/// A dictionary of user-defined parameters and values to include in the request URI query string.
+		/// </param>
+		/// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> token to observe</param>
+		/// <returns>The response content from the custom api invocation.</returns>
+		Task<JToken> InvokeApiAsync(string apiName, JToken body, HttpMethod method, IDictionary<string, string> parameters, CancellationToken cancellationToken);
+
         /// <summary>
         /// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using the specified HttpMethod.
         /// Additional data can be sent though the HTTP content or the query string. 
@@ -255,6 +352,23 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// </param>
         /// <returns>The HTTP Response from the custom api invocation.</returns>
         Task<HttpResponseMessage> InvokeApiAsync(string apiName, HttpContent content, HttpMethod method, IDictionary<string, string> requestHeaders, IDictionary<string, string> parameters);
+
+		/// <summary>
+		/// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using the specified HttpMethod.
+		/// Additional data can be sent though the HTTP content or the query string. 
+		/// </summary>
+		/// <param name="apiName">The name of the custom API.</param>
+		/// <param name="content">The HTTP content.</param>
+		/// <param name="method">The HTTP method.</param>
+		/// <param name="requestHeaders">
+		/// A dictionary of user-defined headers to include in the HttpRequest.
+		/// </param>
+		/// <param name="parameters">
+		/// A dictionary of user-defined parameters and values to include in the request URI query string.
+		/// </param>
+		/// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> token to observe</param>
+		/// <returns>The HTTP Response from the custom api invocation.</returns>
+		Task<HttpResponseMessage> InvokeApiAsync(string apiName, HttpContent content, HttpMethod method, IDictionary<string, string> requestHeaders, IDictionary<string, string> parameters, CancellationToken cancellationToken);
 
         /// <summary>
         /// Gets or sets the settings used for serialization.

--- a/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/MobileServiceClient.cs
+++ b/sdk/Managed/src/Microsoft.WindowsAzure.MobileServices/MobileServiceClient.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.WindowsAzure.MobileServices.Sync;
 using Newtonsoft.Json.Linq;
@@ -374,10 +375,37 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// </summary>
         /// <typeparam name="T">The type of instance returned from the Microsoft Azure Mobile Service.</typeparam>    
         /// <param name="apiName">The name of the custom API.</param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> token to observe</param>
+        /// <returns>The response content from the custom api invocation.</returns>
+        public Task<T> InvokeApiAsync<T>(string apiName, CancellationToken cancellationToken)
+        {
+            return this.InvokeApiAsync<string, T>(apiName, null, null, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using an HTTP POST.
+        /// </summary>
+        /// <typeparam name="T">The type of instance returned from the Microsoft Azure Mobile Service.</typeparam>    
+        /// <param name="apiName">The name of the custom API.</param>
         /// <returns>The response content from the custom api invocation.</returns>
         public Task<T> InvokeApiAsync<T>(string apiName)
         {
             return this.InvokeApiAsync<string, T>(apiName, null, null, null);
+        }
+
+        /// <summary>
+        /// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using an HTTP POST with
+        /// support for sending HTTP content.
+        /// </summary>
+        /// <typeparam name="T">The type of instance sent to the Microsoft Azure Mobile Service.</typeparam>
+        /// <typeparam name="U">The type of instance returned from the Microsoft Azure Mobile Service.</typeparam>    
+        /// <param name="apiName">The name of the custom API.</param>
+        /// <param name="body">The value to be sent as the HTTP body.</param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> token to observe</param>
+        /// <returns>The response content from the custom api invocation.</returns>
+        public Task<U> InvokeApiAsync<T, U>(string apiName, T body, CancellationToken cancellationToken)
+        {
+            return this.InvokeApiAsync<T, U>(apiName, body, null, null, cancellationToken);
         }
 
         /// <summary>
@@ -404,10 +432,63 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// <param name="parameters">
         /// A dictionary of user-defined parameters and values to include in the request URI query string.
         /// </param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> token to observe</param>
+        /// <returns>The response content from the custom api invocation.</returns>
+        public Task<T> InvokeApiAsync<T>(string apiName, HttpMethod method, IDictionary<string, string> parameters, CancellationToken cancellationToken)
+        {
+            return this.InvokeApiAsync<string, T>(apiName, null, method, parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using the specified HTTP Method.
+        /// Additional data can be passed using the query string.
+        /// </summary>
+        /// <typeparam name="T">The type of instance sent to the Microsoft Azure Mobile Service.</typeparam>
+        /// <param name="apiName">The name of the custom API.</param>
+        /// <param name="method">The HTTP method.</param>
+        /// <param name="parameters">
+        /// A dictionary of user-defined parameters and values to include in the request URI query string.
+        /// </param>
         /// <returns>The response content from the custom api invocation.</returns>
         public Task<T> InvokeApiAsync<T>(string apiName, HttpMethod method, IDictionary<string, string> parameters)
         {
             return this.InvokeApiAsync<string, T>(apiName, null, method, parameters);
+        }
+
+        /// <summary>
+        /// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using the specified HTTP Method.
+        /// Additional data can be sent though the HTTP content or the query string.
+        /// </summary>
+        /// <typeparam name="T">The type of instance sent to the Microsoft Azure Mobile Service.</typeparam>
+        /// <typeparam name="U">The type of instance returned from the Microsoft Azure Mobile Service.</typeparam>    
+        /// <param name="apiName">The name of the custom API.</param>
+        /// <param name="body">The value to be sent as the HTTP body.</param>
+        /// <param name="method">The HTTP method.</param>
+        /// <param name="parameters">
+        /// A dictionary of user-defined parameters and values to include in the request URI query string.
+        /// </param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> token to observe</param>
+        /// <returns>The response content from the custom api invocation.</returns>
+        public async Task<U> InvokeApiAsync<T, U>(string apiName, T body, HttpMethod method, IDictionary<string, string> parameters, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(apiName))
+            {
+                throw new ArgumentNullException("apiName");
+            }
+
+            MobileServiceSerializer serializer = this.Serializer;
+            string content = null;
+            if (body != null)
+            {
+                content = serializer.Serialize(body).ToString();
+            }
+
+            string response = await this.InternalInvokeApiAsync(apiName, content, method, parameters, MobileServiceFeatures.TypedApiCall, cancellationToken);
+            if (string.IsNullOrEmpty(response))
+            {
+                return default(U);
+            }
+            return serializer.Deserialize<U>(JToken.Parse(response));
         }
 
         /// <summary>
@@ -449,10 +530,34 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using an HTTP POST.
         /// </summary>
         /// <param name="apiName">The name of the custom API.</param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> token to observe</param>
+        /// <returns></returns>
+        public Task<JToken> InvokeApiAsync(string apiName, CancellationToken cancellationToken)
+        {
+            return this.InvokeApiAsync(apiName, null, null, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using an HTTP POST.
+        /// </summary>
+        /// <param name="apiName">The name of the custom API.</param>
         /// <returns></returns>
         public Task<JToken> InvokeApiAsync(string apiName)
         {
             return this.InvokeApiAsync(apiName, null, null, null);
+        }
+
+        /// <summary>
+        /// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using an HTTP POST, with
+        /// support for sending HTTP content.
+        /// </summary>
+        /// <param name="apiName">The name of the custom API.</param>
+        /// <param name="body">The value to be sent as the HTTP body.</param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> token to observe</param>
+        /// <returns>The response content from the custom api invocation.</returns>
+        public Task<JToken> InvokeApiAsync(string apiName, JToken body, CancellationToken cancellationToken)
+        {
+            return this.InvokeApiAsync(apiName, body, defaultHttpMethod, null, cancellationToken);
         }
 
         /// <summary>
@@ -476,10 +581,66 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// <param name="parameters">
         /// A dictionary of user-defined parameters and values to include in the request URI query string.
         /// </param>        
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> token to observe</param>
+        /// <returns>The response content from the custom api invocation.</returns>
+        public Task<JToken> InvokeApiAsync(string apiName, HttpMethod method, IDictionary<string, string> parameters, CancellationToken cancellationToken)
+        {
+            return this.InvokeApiAsync(apiName, null, method, parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using the specified HTTP Method.
+        /// Additional data will sent to through the query string.
+        /// </summary>
+        /// <param name="apiName">The name of the custom API.</param>
+        /// <param name="method">The HTTP method.</param>
+        /// <param name="parameters">
+        /// A dictionary of user-defined parameters and values to include in the request URI query string.
+        /// </param>        
         /// <returns>The response content from the custom api invocation.</returns>
         public Task<JToken> InvokeApiAsync(string apiName, HttpMethod method, IDictionary<string, string> parameters)
         {
             return this.InvokeApiAsync(apiName, null, method, parameters);
+        }
+
+        /// <summary>
+        /// Invokes a user-defined custom API of a Microsoft Azure Mobile Service using the specified HTTP method.
+        /// Additional data can be sent though the HTTP content or the query string.
+        /// </summary>
+        /// <param name="apiName">The name of the custom API.</param>
+        /// <param name="body">The value to be sent as the HTTP body.</param>
+        /// <param name="method">The HTTP Method.</param>
+        /// <param name="parameters">
+        /// A dictionary of user-defined parameters and values to include in the request URI query string.
+        /// </param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> token to observe</param>
+        /// <returns>The response content from the custom api invocation.</returns>
+        public async Task<JToken> InvokeApiAsync(string apiName, JToken body, HttpMethod method, IDictionary<string, string> parameters, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(apiName))
+            {
+                throw new ArgumentNullException("apiName");
+            }
+
+            string content = null;
+            if (body != null)
+            {
+                switch (body.Type)
+                {
+                    case JTokenType.Null:
+                        content = "null";
+                        break;
+                    case JTokenType.Boolean:
+                        content = body.ToString().ToLowerInvariant();
+                        break;
+                    default:
+                        content = body.ToString();
+                        break;
+                }
+            }
+
+            string response = await this.InternalInvokeApiAsync(apiName, content, method, parameters, MobileServiceFeatures.JsonApiCall, cancellationToken);
+            return response.ParseToJToken(this.SerializerSettings);
         }
 
         /// <summary>
@@ -522,6 +683,75 @@ namespace Microsoft.WindowsAzure.MobileServices
         }
 
         /// <summary>
+        /// Invokes a user-defined custom API of a Windows Azure Mobile Service using the specified HttpMethod.
+        /// Additional data can be sent though the HTTP content or the query string. 
+        /// </summary>
+        /// <param name="apiName">The name of the custom AP.</param>
+        /// <param name="content">The HTTP content.</param>
+        /// <param name="method">The HTTP method.</param>
+        /// <param name="requestHeaders">
+        /// A dictionary of user-defined headers to include in the HttpRequest.
+        /// </param>
+        /// <param name="parameters">
+        /// A dictionary of user-defined parameters and values to include in the request URI query string.
+        /// </param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> token to observe</param>
+        /// <returns>The HTTP Response from the custom api invocation.</returns>
+        public async Task<HttpResponseMessage> InvokeApiAsync(string apiName, HttpContent content, HttpMethod method, IDictionary<string, string> requestHeaders, IDictionary<string, string> parameters, CancellationToken cancellationToken)
+        {
+            method = method ?? defaultHttpMethod;
+            HttpResponseMessage response = await this.HttpClient.RequestAsync(method, CreateAPIUriString(apiName, parameters), this.CurrentUser, content, requestHeaders: requestHeaders, features: MobileServiceFeatures.GenericApiCall, cancellationToken: cancellationToken);
+            return response;
+        }
+
+        /// <summary>
+        /// Invokes a user-defined custom API of a Windows Azure Mobile Service using the specified HttpMethod.
+        /// Additional data can be sent though the HTTP content or the query string. 
+        /// </summary>
+        /// <param name="apiName">The name of the custom AP.</param>
+        /// <param name="content">The HTTP content.</param>
+        /// <param name="method">The HTTP method.</param>
+        /// <param name="requestHeaders">
+        /// A dictionary of user-defined headers to include in the HttpRequest.
+        /// </param>
+        /// <param name="parameters">
+        /// A dictionary of user-defined parameters and values to include in the request URI query string.
+        /// </param>
+        /// <returns>The HTTP Response from the custom api invocation.</returns>
+        public async Task<HttpResponseMessage> InvokeApiAsync(string apiName, HttpContent content, HttpMethod method, IDictionary<string, string> requestHeaders, IDictionary<string, string> parameters)
+        {
+            method = method ?? defaultHttpMethod;
+            HttpResponseMessage response = await this.HttpClient.RequestAsync(method, CreateAPIUriString(apiName, parameters), this.CurrentUser, content, requestHeaders: requestHeaders, features: MobileServiceFeatures.GenericApiCall);
+            return response;
+        }
+
+        /// <summary>
+        /// Invokes a user-defined custom API of a Microsoft Azure Mobile Service.
+        /// </summary>
+        /// <param name="apiName">The name of the custom API.</param>
+        /// <param name="content">The HTTP content, as a string, in json format.</param>
+        /// <param name="method">The HTTP method.</param>
+        /// <param name="parameters">
+        /// A dictionary of user-defined parameters and values to include in the request URI query string.
+        /// </param>
+        /// <param name="features">
+        /// Value indicating which features of the SDK are being used in this call. Useful for telemetry.
+        /// </param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> token to observe</param>
+        /// <returns>The response content from the custom api invocation.</returns>
+        private async Task<string> InternalInvokeApiAsync(string apiName, string content, HttpMethod method, IDictionary<string, string> parameters, MobileServiceFeatures features, CancellationToken cancellationToken)
+        {
+            method = method ?? defaultHttpMethod;
+            if (parameters != null && parameters.Count > 0)
+            {
+                features |= MobileServiceFeatures.AdditionalQueryParameters;
+            }
+
+            MobileServiceHttpResponse response = await this.HttpClient.RequestAsync(method, CreateAPIUriString(apiName, parameters), this.CurrentUser, cancellationToken, content, false, features: features);
+            return response.Content;
+        }
+
+        /// <summary>
         /// Invokes a user-defined custom API of a Microsoft Azure Mobile Service.
         /// </summary>
         /// <param name="apiName">The name of the custom API.</param>
@@ -558,27 +788,6 @@ namespace Microsoft.WindowsAzure.MobileServices
             string queryString = MobileServiceUrlBuilder.GetQueryString(parameters, useTableAPIRules: false);
 
             return MobileServiceUrlBuilder.CombinePathAndQuery(uriFragment, queryString);
-        }
-
-        /// <summary>
-        /// Invokes a user-defined custom API of a Windows Azure Mobile Service using the specified HttpMethod.
-        /// Additional data can be sent though the HTTP content or the query string. 
-        /// </summary>
-        /// <param name="apiName">The name of the custom AP.</param>
-        /// <param name="content">The HTTP content.</param>
-        /// <param name="method">The HTTP method.</param>
-        /// <param name="requestHeaders">
-        /// A dictionary of user-defined headers to include in the HttpRequest.
-        /// </param>
-        /// <param name="parameters">
-        /// A dictionary of user-defined parameters and values to include in the request URI query string.
-        /// </param>
-        /// <returns>The HTTP Response from the custom api invocation.</returns>
-        public async Task<HttpResponseMessage> InvokeApiAsync(string apiName, HttpContent content, HttpMethod method, IDictionary<string, string> requestHeaders, IDictionary<string, string> parameters)
-        {
-            method = method ?? defaultHttpMethod;
-            HttpResponseMessage response = await this.HttpClient.RequestAsync(method, CreateAPIUriString(apiName, parameters), this.CurrentUser, content, requestHeaders: requestHeaders, features: MobileServiceFeatures.GenericApiCall);
-            return response;
         }
 
         /// <summary>
@@ -666,5 +875,6 @@ namespace Microsoft.WindowsAzure.MobileServices
 
             return installationId;
         }
+
     }
 }


### PR DESCRIPTION
I added a CancellationToken paramter to InvokeApi functions.
This modification was requested here: https://github.com/Azure/azure-mobile-services/issues/524